### PR TITLE
fix printing of double

### DIFF
--- a/validator/ast/string.go
+++ b/validator/ast/string.go
@@ -166,7 +166,7 @@ func isId(s string) bool {
 // String returns the validator string representation of the Name instance.
 func (this *Name) String() string {
 	if this.DoubleValue != nil {
-		return this.Before.String() + strconv.FormatFloat(this.GetDoubleValue(), 'f', -1, 64)
+		return this.Before.String() + "double(" + strconv.FormatFloat(this.GetDoubleValue(), 'f', -1, 64) + ")"
 	}
 	if this.IntValue != nil {
 		return this.Before.String() + strconv.FormatInt(this.GetIntValue(), 10)
@@ -251,7 +251,7 @@ func (this *BuiltIn) String() string {
 // String returns the validator string representation of the Terminal instance.
 func (this *Terminal) String() string {
 	if this.DoubleValue != nil {
-		return this.Before.String() + strconv.FormatFloat(this.GetDoubleValue(), 'f', -1, 64)
+		return this.Before.String() + "double(" + strconv.FormatFloat(this.GetDoubleValue(), 'f', -1, 64) + ")"
 	}
 	if this.IntValue != nil {
 		return this.Before.String() + strconv.FormatInt(this.GetIntValue(), 10)

--- a/validator/combinator/funcs_test.go
+++ b/validator/combinator/funcs_test.go
@@ -48,6 +48,12 @@ func TestInt(t *testing.T) {
 	t.Log(Value(ast.NewFunction("print", intFunc(IntVar(), IntConst(rand.Int63())))).String())
 }
 
+func TestDouble1(t *testing.T) {
+	t.Log(Value(GT(DoubleVar(), DoubleConst(1))).String())
+	// checks that double is printed out as `double(1.1)`` surrounded by double(), since `1.1`` alone will not parse.
+	t.Log(Value(GT(DoubleVar(), DoubleConst(1.1))).String())
+}
+
 // TestImmutability tests that the `Value` function does not change the input expression and remove a comma.
 func TestImmutability(t *testing.T) {
 	eq := Eq(UintVar(), UintConst(10))


### PR DESCRIPTION
a double with a dot, like `1.1` needs to surrounded by `double(1.1)` to be able to parse.