### PR TITLE
optimize automaton by also hashing names

### DIFF
--- a/validator/ast/walk.go
+++ b/validator/ast/walk.go
@@ -17,7 +17,7 @@ package ast
 // Visitor is used to do a top down walk through the expression tree using the Walk methods.
 type Visitor interface {
 	//Visit takes in an ast type and should return another type that implementes the Visitor interface.
-	Visit(node interface{}) interface{}
+	Visit(node any) any
 }
 
 // Walk visits the Grammar instance and all its possible child pattern and all its pattern declarations.

--- a/validator/auto/auto.go
+++ b/validator/auto/auto.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"io"
 
+	"github.com/katydid/parser-go/cast"
 	"github.com/katydid/parser-go/parse"
 )
 
@@ -33,6 +34,8 @@ type Auto struct {
 	start           int
 	stateToNullable []int
 	accept          []bool
+
+	hashedCalls []map[string]callResult
 }
 
 // Validate executes an automaton with the given parser and returns whether the parser is valid given the automaton's original grammar.
@@ -46,6 +49,18 @@ func (auto *Auto) Validate(p parse.Parser) (bool, error) {
 
 func (auto *Auto) MetricNumberOfStates() int {
 	return len(auto.accept)
+}
+
+func derivEnterField(auto *Auto, current int, tree parse.Parser) (int, int, error) {
+	kind, name, err := tree.Token()
+	if err == nil && kind == parse.StringKind {
+		res, ok := auto.hashedCalls[current][cast.ToString(name)]
+		if ok {
+			return res.child, res.stackIndex, nil
+		}
+	}
+	callTree := auto.calls[current]
+	return callTree.eval(tree)
 }
 
 func derivEnter(auto *Auto, current int, tree parse.Parser) (int, int, error) {
@@ -93,7 +108,7 @@ func deriv(auto *Auto, current int, tree parse.Parser) (int, error) {
 		case parse.LeaveHint:
 			return current, nil
 		case parse.FieldHint:
-			childState, stackElm, err := derivEnter(auto, current, tree)
+			childState, stackElm, err := derivEnterField(auto, current, tree)
 			if err != nil {
 				return 0, err
 			}

--- a/validator/auto/compile.go
+++ b/validator/auto/compile.go
@@ -72,6 +72,11 @@ func (c *compiler) compile() error {
 			changed = true
 		}
 	}
+	for state := range c.patterns.Len() {
+		if err := c.calcHashCalls(state); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/validator/auto/compile.go
+++ b/validator/auto/compile.go
@@ -49,6 +49,7 @@ func compileAuto(g *ast.Grammar, record bool) (*Auto, error) {
 		start:           c.start,
 		stateToNullable: c.stateToNullable,
 		accept:          c.accept,
+		hashedCalls:     c.hashedCalls,
 	}
 	return a, nil
 }

--- a/validator/auto/compiler.go
+++ b/validator/auto/compiler.go
@@ -101,7 +101,6 @@ func (this *compiler) calcCallTrees(upto int) error {
 			return err
 		}
 		this.calls = append(this.calls, memCallTree)
-		this.calcHashCalls(i)
 	}
 	return nil
 }

--- a/validator/auto/compiler.go
+++ b/validator/auto/compiler.go
@@ -60,6 +60,8 @@ type compiler struct {
 	escapables      []bool
 	stateToNullable []int
 	accept          []bool
+
+	hashedCalls []map[string]callResult
 }
 
 func (this *compiler) calcEscapables(upto int) {
@@ -99,6 +101,7 @@ func (this *compiler) calcCallTrees(upto int) error {
 			return err
 		}
 		this.calls = append(this.calls, memCallTree)
+		this.calcHashCalls(i)
 	}
 	return nil
 }

--- a/validator/auto/hash.go
+++ b/validator/auto/hash.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Walter Schulze
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auto
+
+import (
+	"github.com/katydid/parser-go/parse/debug"
+	"github.com/katydid/validator-go/validator/ast"
+	"github.com/katydid/validator-go/validator/intern"
+)
+
+type stringCollector struct {
+	ss []string
+}
+
+func (c *stringCollector) Visit(node any) any {
+	term, ok := node.(*ast.Terminal)
+	if ok {
+		if term.StringValue != nil {
+			c.ss = append(c.ss, *term.StringValue)
+		}
+	}
+	return c
+}
+
+func getStringsFromPattern(p *intern.Pattern) []string {
+	if p.Func == nil {
+		return nil
+	}
+	expr := p.Func.ToExpr()
+	collector := &stringCollector{[]string{}}
+	expr.Walk(collector)
+	return collector.ss
+}
+
+func getStringsFromPatterns(ps []*intern.Pattern) []string {
+	strings := []string{}
+	for i := range ps {
+		strings = append(strings, getStringsFromPattern(ps[i])...)
+	}
+	return strings
+}
+
+type callResult struct {
+	child      int
+	stackIndex int
+}
+
+func (this *compiler) calcHashCalls(state int) error {
+	ps := this.patterns.Get(state)
+	names := getStringsFromPatterns(ps)
+	for len(this.hashedCalls) <= state {
+		this.hashedCalls = append(this.hashedCalls, map[string]callResult{})
+	}
+	for _, name := range names {
+		child, stackIndex, err := this.calls[state].eval(debug.NewStringValue(name))
+		if err != nil {
+			return err
+		}
+		this.hashedCalls[state][name] = callResult{child: child, stackIndex: stackIndex}
+	}
+	return nil
+}

--- a/validator/auto/hash.go
+++ b/validator/auto/hash.go
@@ -25,23 +25,27 @@ type stringCollector struct {
 }
 
 func (c *stringCollector) Visit(node any) any {
-	term, ok := node.(*ast.Terminal)
-	if ok {
-		if term.StringValue != nil {
-			c.ss = append(c.ss, *term.StringValue)
+	switch t := node.(type) {
+	case *ast.Terminal:
+		if t.StringValue != nil {
+			c.ss = append(c.ss, *t.StringValue)
+		}
+	case *ast.Name:
+		if t.StringValue != nil {
+			c.ss = append(c.ss, *t.StringValue)
 		}
 	}
 	return c
 }
 
 func getStringsFromPattern(p *intern.Pattern) []string {
-	if p.Func == nil {
-		return nil
-	}
-	expr := p.Func.ToExpr()
 	collector := &stringCollector{[]string{}}
-	expr.Walk(collector)
-	return collector.ss
+	if p.Func != nil {
+		expr := p.Func.ToExpr()
+		expr.Walk(collector)
+	}
+	ss := getStringsFromPatterns(p.Patterns)
+	return append(collector.ss, ss...)
 }
 
 func getStringsFromPatterns(ps []*intern.Pattern) []string {
@@ -60,15 +64,14 @@ type callResult struct {
 func (this *compiler) calcHashCalls(state int) error {
 	ps := this.patterns.Get(state)
 	names := getStringsFromPatterns(ps)
-	for len(this.hashedCalls) <= state {
-		this.hashedCalls = append(this.hashedCalls, map[string]callResult{})
-	}
-	for _, name := range names {
-		child, stackIndex, err := this.calls[state].eval(debug.NewStringValue(name))
+	hashed := map[string]callResult{}
+	for i := range names {
+		child, stackIndex, err := this.calls[state].eval(debug.NewStringValue(names[i]))
 		if err != nil {
 			return err
 		}
-		this.hashedCalls[state][name] = callResult{child: child, stackIndex: stackIndex}
+		hashed[names[i]] = callResult{child: child, stackIndex: stackIndex}
 	}
+	this.hashedCalls = append(this.hashedCalls, hashed)
 	return nil
 }

--- a/validator/funcs/register.go
+++ b/validator/funcs/register.go
@@ -26,7 +26,7 @@ var errTyp = reflect.TypeOf((*error)(nil)).Elem()
 var funcTyp = reflect.TypeOf((*Func)(nil)).Elem()
 
 // Register registers a function as function that can composed.
-func Register(name string, fnc interface{}) {
+func Register(name string, fnc any) {
 	typ := reflect.TypeOf(fnc)
 	if typ.Kind() != reflect.Func {
 		panic(fmt.Sprintf("expecting constructor function for %s, but got %T", name, fnc))


### PR DESCRIPTION
We find any constant strings in the patterns of a state and then evaluate the call using that constant and save the answer in a hash map

Then we take the derivative of a field we first check if we can find the answer in the map.
This is faster, since we can now do one lookup, instead of multiple comparisons to get the call result.

This optimization is an approximation of the hashes mentioned in the Blaze paper: `Blaze: Compiling JSON Schema for 10× Faster Validation`