### PR TITLE
Optimization for namesets

### DIFF
--- a/validator/ast/names.go
+++ b/validator/ast/names.go
@@ -32,10 +32,10 @@ func (n *NameExpr) GetConstNames() map[string]struct{} {
 
 func (n *Name) GetConstNames() map[string]struct{} {
 	if n.StringValue != nil {
-		return map[string]struct{}{*n.StringValue: struct{}{}}
+		return map[string]struct{}{*n.StringValue: {}}
 	}
 	if n.TagValue != nil {
-		return map[string]struct{}{*n.TagValue: struct{}{}}
+		return map[string]struct{}{*n.TagValue: {}}
 	}
 	return nil
 }

--- a/validator/intern/simplify_test.go
+++ b/validator/intern/simplify_test.go
@@ -15,6 +15,7 @@
 package intern_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/katydid/validator-go/validator/ast"
@@ -314,5 +315,28 @@ func TestSimplifyRecordLeaf2(t *testing.T) {
 	t.Logf("%v", got)
 	if !want.Equal(got) {
 		t.Fatalf("want %v, but got %v", want, got)
+	}
+}
+
+func TestSimplifyNameSets(t *testing.T) {
+	c := NewConstructor()
+	p, err := c.NewPattern(ast.NewTreeNode(ast.NewAnyNameExcept(ast.NewNameChoice(
+		ast.NewStringName("a"),
+		ast.NewStringName("b"),
+		ast.NewStringName("c"),
+		ast.NewStringName("d"),
+		ast.NewStringName("e"),
+	)), ast.NewZAny()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := p.Func.ToExpr()
+	s := e.String()
+	want := `->not(contains($string,[]string{"a","b","c","d","e"}))`
+	if !strings.Contains(s, `contains`) {
+		t.Fatalf("expected simplification of name set to a contains expression, like %s", want)
+	}
+	if !strings.Contains(s, `[]string{"a","b","c","d","e"}`) {
+		t.Fatalf("expected simplification of name set to a contains expression, like %s", want)
 	}
 }

--- a/validator/name/name.go
+++ b/validator/name/name.go
@@ -71,6 +71,10 @@ func NameToFunc(n *ast.NameExpr) (funcs.Bool, error) {
 		}
 		return funcs.Not(n), nil
 	case *ast.NameChoice:
+		set, ok := getStringSet(n)
+		if ok && len(set) > 4 {
+			return funcs.ContainsString(funcs.StringVar(), funcs.NewListOfString(set))
+		}
 		l, err := NameToFunc(v.GetLeft())
 		if err != nil {
 			return nil, err
@@ -81,10 +85,6 @@ func NameToFunc(n *ast.NameExpr) (funcs.Bool, error) {
 		}
 		return funcs.Or(l, r), nil
 	case *ast.NameConj:
-		set, ok := getStringSet(n)
-		if ok && len(set) > 4 {
-			return funcs.ContainsString(funcs.StringVar(), funcs.NewListOfString(set))
-		}
 		l, err := NameToFunc(v.GetLeft())
 		if err != nil {
 			return nil, err

--- a/validator/name/name.go
+++ b/validator/name/name.go
@@ -81,6 +81,10 @@ func NameToFunc(n *ast.NameExpr) (funcs.Bool, error) {
 		}
 		return funcs.Or(l, r), nil
 	case *ast.NameConj:
+		set, ok := getStringSet(n)
+		if ok && len(set) > 4 {
+			return funcs.ContainsString(funcs.StringVar(), funcs.NewListOfString(set))
+		}
 		l, err := NameToFunc(v.GetLeft())
 		if err != nil {
 			return nil, err
@@ -99,4 +103,20 @@ func NameToFunc(n *ast.NameExpr) (funcs.Bool, error) {
 		return compose.NewBool(f.ToExpr())
 	}
 	panic(fmt.Sprintf("unknown name expr typ %T", typ))
+}
+
+func getStringSet(n *ast.NameExpr) ([]funcs.String, bool) {
+	typ := n.GetValue()
+	switch v := typ.(type) {
+	case *ast.Name:
+		if v.StringValue == nil {
+			return nil, false
+		}
+		return []funcs.String{funcs.StringConst(v.GetStringValue())}, true
+	case *ast.NameChoice:
+		lset, lok := getStringSet(v.GetLeft())
+		rset, rok := getStringSet(v.GetRight())
+		return append(lset, rset...), lok && rok
+	}
+	return nil, false
 }

--- a/validator/name/name.go
+++ b/validator/name/name.go
@@ -73,6 +73,7 @@ func NameToFunc(n *ast.NameExpr) (funcs.Bool, error) {
 	case *ast.NameChoice:
 		set, ok := getStringSet(n)
 		if ok && len(set) > 4 {
+			// This is useful for large sets of names, which happens when translating additionalProperties from JSON Schema
 			return funcs.ContainsString(funcs.StringVar(), funcs.NewListOfString(set))
 		}
 		l, err := NameToFunc(v.GetLeft())


### PR DESCRIPTION
This is useful for avoiding a lot of equalities comparisons when simply checking if a name is in a set, which is what additionalProperties in JSON Schema translates to.